### PR TITLE
Single and Multi-Line Copy Functionality

### DIFF
--- a/custom/99-shortcuts.el
+++ b/custom/99-shortcuts.el
@@ -57,3 +57,27 @@
 
 ;; Paste a link into an org file.
 (global-set-key (kbd "C-x p i") 'org-cliplink)
+
+;; Duplicate whole line
+(global-set-key (kbd "\C-c\C-k") 'copy-line)
+
+(defun copy-line (arg)
+  "Copy lines (as many as prefix argument) in the kill ring.
+      Ease of use features:
+      - Stay at current position.
+      - Appends the copy on sequential calls.
+      - Use newline as last char even on the last line of the buffer.
+      - If region is active, copy its lines."
+  (interactive "p")
+  (let ((beg (line-beginning-position))
+        (end (line-end-position arg)))
+    (when mark-active
+      (if (> (point) (mark))
+          (setq beg (save-excursion (goto-char (mark)) (line-beginning-position)))
+        (setq end (save-excursion (goto-char (mark)) (line-end-position)))))
+    (if (eq last-command 'copy-line)
+        (kill-append (buffer-substring beg end) (< end beg))
+      (kill-ring-save beg end)))
+  (kill-append "\n" nil)
+  (arg (1+ arg)) 2))
+(if (arg (not (= 1 arg))) (message "%d lines copied" arg)))

--- a/custom/99-shortcuts.el
+++ b/custom/99-shortcuts.el
@@ -79,5 +79,5 @@
         (kill-append (buffer-substring beg end) (< end beg))
       (kill-ring-save beg end)))
   (kill-append "\n" nil)
-  (arg (1+ arg)) 2))
-(if (arg (not (= 1 arg))) (message "%d lines copied" arg)))
+  (arg (1+ arg)) 2
+  (if (arg (not (= 1 arg))) (message "%d lines copied" arg))))


### PR DESCRIPTION
C-c C-k to do a single line copy which will maintain cursor position

Can also specifiy a multi line copy. E.g. C-3 C-c C-k, to copy the current line and the two below lines
